### PR TITLE
Added Lint targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,3 +164,12 @@ appstore:
 test: composer
 	$(CURDIR)/vendor/phpunit/phpunit/phpunit -c phpunit.xml
 	$(CURDIR)/vendor/phpunit/phpunit/phpunit -c phpunit.integration.xml
+
+.PHONY: lint
+lint: composer
+	composer run lint
+	composer run cs:check
+
+.PHONY: lint-fix
+lint-fix: composer
+	composer run cs:fix


### PR DESCRIPTION
The following two targets

  - lint
  - lint-fix

are added to the Makefile to execute a source code check (lint) and to fix detected source code issues (lint-fix).