### PR TITLE
Update repo name to be consistent with NC defaults

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,17 +6,18 @@ on:
       - master
       - stable*
 
+env:
+  APP_NAME: workflow_ocr
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          path: workflow_ocr
       - name: Run Makefile
-        run: cd workflow_ocr && make appstore
+        run: cd ${{ env.APP_NAME }} && make appstore
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:
-          name: workflow_ocr.tar.gz 
-          path: workflow_ocr/build/artifacts/appstore/workflow_ocr.tar.gz      
+          name: ${{ env.APP_NAME }}.tar.gz 
+          path: ${{ env.APP_NAME }}/build/artifacts/appstore/${{ env.APP_NAME }}.tar.gz      

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor
 coverage*.xml
 build
 .phpunit.result.cache
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 
 # Nextcloud Workflow OCR app
-![PHPUnit](https://github.com/R0Wi/nextcloud_workflow_ocr/workflows/PHPUnit/badge.svg)
-[![codecov](https://codecov.io/gh/R0Wi/nextcloud_workflow_ocr/branch/master/graph/badge.svg)](https://codecov.io/gh/R0Wi/nextcloud_workflow_ocr)
-![Lint](https://github.com/R0Wi/nextcloud_workflow_ocr/workflows/Lint/badge.svg)
-[![Generic badge](https://img.shields.io/github/v/release/R0Wi/nextcloud_workflow_ocr)](https://github.com/R0Wi/nextcloud_workflow_ocr/releases)
+![PHPUnit](https://github.com/R0Wi/workflow_ocr/workflows/PHPUnit/badge.svg)
+[![codecov](https://codecov.io/gh/R0Wi/workflow_ocr/branch/master/graph/badge.svg)](https://codecov.io/gh/R0Wi/workflow_ocr)
+![Lint](https://github.com/R0Wi/workflow_ocr/workflows/Lint/badge.svg)
+[![Generic badge](https://img.shields.io/github/v/release/R0Wi/workflow_ocr)](https://github.com/R0Wi/workflow_ocr/releases)
 [![Generic badge](https://img.shields.io/badge/Nextcloud-19-orange)](https://github.com/nextcloud/server)
 
 ## Table of contents
@@ -25,10 +25,10 @@
 
 ## Setup
 ### App installation
-First download and install the Nextcloud Workflow OCR app from the official Nexcloud-appstore or by downloading the appropriate tarball from the [releases](https://github.com/R0Wi/nextcloud_workflow_ocr/releases) page. 
+First download and install the Nextcloud Workflow OCR app from the official Nexcloud-appstore or by downloading the appropriate tarball from the [releases](https://github.com/R0Wi/workflow_ocr/releases) page. 
 ```bash
 cd /var/www/<NEXTCLOUD_INSTALL>/apps
-wget https://github.com/R0Wi/nextcloud_workflow_ocr/releases/download/<VERSION>/workflow_ocr.tar.gz
+wget https://github.com/R0Wi/workflow_ocr/releases/download/<VERSION>/workflow_ocr.tar.gz
 tar -xzvf workflow_ocr.tar.gz
 rm workflow_ocr.tar.gz
 ```
@@ -115,7 +115,7 @@ Tools and packages you need for development:
 You can then build and install the app by cloning this repository into the Nextcloud apps folder and running `make build`.
 ```bash
 cd /var/www/<NEXTCLOUD_INSTALL>/apps
-git clone https://github.com/R0Wi/nextcloud_workflow_ocr.git workflow_ocr
+git clone https://github.com/R0Wi/workflow_ocr.git workflow_ocr
 cd workflow_ocr
 make build
 ```


### PR DESCRIPTION
Repo name changed from `nextcloud_workflow_ocr` to `workflow_ocr` to be consistent with NC defaults.