### PR TITLE
Manual backport of 'Use IRuleMatcher getFlows (closes #60) (#61)' for NC 21

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -85,7 +85,7 @@ jobs:
 
     services:
       mysql:
-        image: mariadb
+        image: mariadb:10.5
         ports:
           - 4444:3306/tcp
         env:


### PR DESCRIPTION
* Use IRuleMatcher getFlows

Filter unwanted events for users
by invoking ruleMatchers getFlows method.
This will apply various checks and only
return a value if all checks passed.

Fixes #60

* "Fix" CI with mariadb

Inspired by
https://github.com/nextcloud/spreed/commit/e8b1456f064b2e9d07aed01c87f25360addeb8d4