### PR TITLE
Accept results with ocrmypdf exit code 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,12 @@ That's all. If you now create a new workflow based on your added mimetype, your 
   <p align="center">
     <img width="75%" src="doc/img/file_versions.jpg" alt="File versions">
   </p>
+  If you want to clean the files history for all files and only preserve the newest file version, you can use
+  
+  ```bash
+  sudo -u www-data php occ versions:cleanup
+  ```
+  Read more about this in the [docs](https://docs.nextcloud.com/server/stable/admin_manual/configuration_server/occ_command.html?#versions).
 
 ## Used libraries & components
 | Name | Version | Link |

--- a/lib/BackgroundJobs/ProcessFileJob.php
+++ b/lib/BackgroundJobs/ProcessFileJob.php
@@ -155,17 +155,17 @@ class ProcessFileJob extends \OC\BackgroundJob\QueuedJob {
 		}
 
 		if (!$node instanceof Node || $node->getType() !== FileInfo::TYPE_FILE) {
-			$this->logger->info('Skipping process for \'' . $filePath . '\'. It is not a file');
+			$this->logger->warning('Skipping process for \'' . $filePath . '\'. It is not a file');
 			return;
 		}
 
 		try {
 			$ocrFile = $this->ocrFile($node);
 		} catch (OcrNotPossibleException $ocrNpEx) {
-			$this->logger->info('OCR for file ' . $node->getPath() . ' not possible. Message: ' . $ocrNpEx->getMessage());
+			$this->logger->error('OCR for file ' . $node->getPath() . ' not possible. Message: ' . $ocrNpEx->getMessage());
 			return;
 		} catch (OcrProcessorNotFoundException $ocrProcNfEx) {
-			$this->logger->info('OCR processor not found for mimetype ' . $node->getMimeType());
+			$this->logger->error('OCR processor not found for mimetype ' . $node->getMimeType());
 			return;
 		}
 

--- a/lib/OcrProcessors/OcrProcessorFactory.php
+++ b/lib/OcrProcessors/OcrProcessorFactory.php
@@ -27,6 +27,7 @@ use OCA\WorkflowOcr\Exception\OcrProcessorNotFoundException;
 use OCA\WorkflowOcr\Wrapper\ICommand;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 class OcrProcessorFactory implements IOcrProcessorFactory {
 	private static $mapping = [
@@ -49,7 +50,7 @@ class OcrProcessorFactory implements IOcrProcessorFactory {
 		*	under the hood.
 		*/
 		$context->registerService(PdfOcrProcessor::class, function (ContainerInterface $c) {
-			return new PdfOcrProcessor($c->get(ICommand::class));
+			return new PdfOcrProcessor($c->get(ICommand::class), $c->get(LoggerInterface::class));
 		}, false);
 	}
 

--- a/tests/Unit/BackgroundJobs/ProcessFileJobTest.php
+++ b/tests/Unit/BackgroundJobs/ProcessFileJobTest.php
@@ -291,7 +291,7 @@ class ProcessFileJobTest extends TestCase {
 	/**
 	 * @dataProvider dataProvider_OcrExceptions
 	 */
-	public function testLogsInfo_OnOcrException(Exception $exception) {
+	public function testLogsError_OnOcrException(Exception $exception) {
 		$arguments = ['filePath' => '/admin/files/someInvalidStuff', 'uid' => 'admin'];
 		$this->processFileJob->setArgument($arguments);
 
@@ -304,7 +304,7 @@ class ProcessFileJobTest extends TestCase {
 			->willThrowException($exception);
 		
 		$this->logger->expects($this->once())
-			->method('info');
+			->method('error');
 
 		$this->viewFactory->expects($this->never())
 			->method('create');

--- a/tests/Unit/OperationTest.php
+++ b/tests/Unit/OperationTest.php
@@ -315,8 +315,7 @@ class OperationTest extends TestCase {
 
 	public function dataProvider_InvalidRuleMatcherResults() {
 		return [
-			[ [] ],
-			[ null ]
+			[ [] ]
 		];
 	}
 


### PR DESCRIPTION
With respect to the [`ocrmypdf`-docs](https://ocrmypdf.readthedocs.io/en/latest/advanced.html#return-code-policy) and the [reference server implementation](https://github.com/jbarlow83/OCRmyPDF/blob/313c9e7dc171351126ad6dac3d5b46cea27cc6f7/misc/webservice.py#L63) we should accept all OCR results where `ocrmypdf` command succeeds with exitcode 0.