### PR TITLE
[Backport stable22] Bump node-fetch from 2.6.6 to 2.6.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20860,15 +20860,23 @@
 			}
 		},
 		"node_modules/node-fetch": {
-			"version": "2.6.6",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-			"integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
 			"dev": true,
 			"dependencies": {
 				"whatwg-url": "^5.0.0"
 			},
 			"engines": {
 				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/node-forge": {
@@ -48300,9 +48308,9 @@
 			}
 		},
 		"node-fetch": {
-			"version": "2.6.6",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-			"integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
 			"dev": true,
 			"requires": {
 				"whatwg-url": "^5.0.0"


### PR DESCRIPTION
Backport 759c43fdc374f3385da3a5dc1d8bee8547011ef5 from #90